### PR TITLE
Remote cli

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -46,6 +46,7 @@ func init() {
 	BravetoolsCmd.AddCommand(baseBuild)
 	BravetoolsCmd.AddCommand(braveVersion)
 	BravetoolsCmd.AddCommand(braveCompose)
+	BravetoolsCmd.AddCommand(remoteCmd)
 
 	userHome, _ := os.UserHomeDir()
 	exists, err := shared.CheckPath(path.Join(userHome, shared.PlatformConfig))

--- a/commands/remote.go
+++ b/commands/remote.go
@@ -1,0 +1,147 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/bravetools/bravetools/platform"
+	"github.com/bravetools/bravetools/shared"
+	"github.com/spf13/cobra"
+)
+
+var remoteCmd = &cobra.Command{
+	Use:   "remote",
+	Short: "Manage remotes",
+	Long:  ``,
+}
+
+var remoteAddCmd = &cobra.Command{
+	Use:   "add [NAME] [URL]",
+	Short: "Add a remote",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 2 {
+			cmd.Usage()
+			return fmt.Errorf("`brave remote add` expects two positional args, [NAME] and [URL], got %d", len(args))
+		}
+		return nil
+	},
+	Long: `Create a remote called [NAME] available at [URL].
+Example: brave remote add test https://localhost:8443`,
+	Run: remoteAdd,
+}
+
+var remoteRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove a remote",
+	Long:  ``,
+	Args:  cobra.MinimumNArgs(1),
+	Run:   remoteRemove,
+}
+
+var remoteGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get a remote",
+	Long:  "",
+	Args:  cobra.ExactArgs(1),
+	Run:   remoteGet,
+}
+
+var remoteListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all remotes",
+	Long:  "",
+	Args:  cobra.NoArgs,
+	Run:   remoteList,
+}
+
+var remoteArgs = &platform.Remote{}
+var remotePassword = ""
+
+func init() {
+	remoteCmd.AddCommand(remoteAddCmd)
+	remoteCmd.AddCommand(remoteRemoveCmd)
+	remoteCmd.AddCommand(remoteGetCmd)
+	remoteCmd.AddCommand(remoteListCmd)
+	includeRemoteAddFlags(remoteAddCmd)
+}
+
+func includeRemoteAddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&remoteArgs.Protocol, "protocol", "lxd", "LXD server protocol to connect with (e.g. 'lxd', 'simplestreams')")
+	cmd.Flags().BoolVar(&remoteArgs.Public, "public", false, "Publicly available server with no authentication")
+	cmd.Flags().StringVar(&remoteArgs.Profile, "profile", "", "Name of LXD profile to use with this remote by default (e.g. 'bravetools')")
+	cmd.Flags().StringVar(&remotePassword, "password", "", "Trusted password to use when communicating with remote")
+}
+
+func remoteAdd(cmd *cobra.Command, args []string) {
+
+	remoteArgs.Name = args[0]
+	remoteArgs.URL = args[1]
+
+	err := platform.SaveRemote(*remoteArgs)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Need to generate certs for non-public remotes
+	if !remoteArgs.Public && !(remoteArgs.Protocol == "unix") {
+
+		if remotePassword == "" {
+			log.Println("adding a non-public remote without providing a trusted password with the --password flag only works with remotes that already trust bravetools")
+		}
+
+		err = platform.AddRemote(*remoteArgs, remotePassword)
+		if err != nil {
+			platform.RemoveRemote(remoteArgs.Name)
+			log.Fatal(err)
+		}
+	} else {
+		// Validate public/unix connection
+		if remoteArgs.Protocol == "unix" {
+			_, err = platform.GetLXDInstanceServer(*remoteArgs)
+		} else {
+			_, err = platform.GetLXDImageSever(*remoteArgs)
+		}
+
+		if err != nil {
+			platform.RemoveRemote(remoteArgs.Name)
+			log.Fatal(err)
+		}
+	}
+}
+
+func remoteRemove(cmd *cobra.Command, args []string) {
+	for _, arg := range args {
+		if arg == shared.BravetoolsRemote {
+			log.Printf("remote %q cannot be removed, skipping", arg)
+			continue
+		}
+
+		err := platform.RemoveRemote(arg)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+func remoteGet(cmd *cobra.Command, args []string) {
+	remote, err := platform.LoadRemoteSettings(args[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+	remoteJson, err := json.MarshalIndent(remote, "", "    ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(remoteJson))
+}
+
+func remoteList(cmd *cobra.Command, args []string) {
+	remoteNames, err := platform.ListRemotes()
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, name := range remoteNames {
+		fmt.Println(name)
+	}
+}

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -176,9 +176,30 @@ func AddRemote(remote Remote, password string) error {
 	if err != nil {
 		return err
 	}
-	err = lxdServer.CreateCertificate(req)
+
+	// Ensure we are not already trusted by server before adding cert
+	server, _, err := lxdServer.GetServer()
 	if err != nil {
 		return err
+	}
+	if server.Auth != "trusted" {
+		err = lxdServer.CreateCertificate(req)
+		if err != nil {
+			return err
+		}
+
+		// Reconnect and check if now trusted
+		lxdServer, err = GetLXDInstanceServer(remote)
+		if err != nil {
+			return err
+		}
+		server, _, err = lxdServer.GetServer()
+		if err != nil {
+			return err
+		}
+		if server.Auth != "trusted" {
+			return errors.New("failed to authenticate with server - still not trusted after adding cert")
+		}
 	}
 
 	return nil

--- a/platform/operations.go
+++ b/platform/operations.go
@@ -215,9 +215,13 @@ func RemoveRemote(name string) error {
 	if err != nil {
 		return err
 	}
-	err = os.Remove(certs)
-	if err != nil {
-		return err
+
+	// Remove associated cert if it exists
+	if shared.FileExists(certs) {
+		err = os.Remove(certs)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/platform/remotes.go
+++ b/platform/remotes.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/bravetools/bravetools/shared"
@@ -133,6 +134,25 @@ func SaveRemote(remote Remote) error {
 	}
 
 	return os.WriteFile(path, remoteJson, 0666)
+}
+
+func ListRemotes() (names []string, err error) {
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		return names, errors.New("failed to list remotes: " + err.Error())
+	}
+
+	dir, err := os.Open(path.Join(userHome, shared.BraveRemoteStore))
+	if err != nil {
+		return names, errors.New("failed to list remotes: " + err.Error())
+	}
+
+	names, err = dir.Readdirnames(-1)
+	for i := range names {
+		names[i] = strings.TrimSuffix(names[i], filepath.Ext(names[i]))
+	}
+
+	return names, err
 }
 
 func loadKey(path string) (string, error) {


### PR DESCRIPTION
This PR adds a remote command to the CLI that manages remotes. Allows for creation/get/list/delete of remotes. When adding a new remote, can handle authenticating with other server if trust password provided.